### PR TITLE
Add groupsOf:step: method to SequenceableCollection extension.

### DIFF
--- a/src/CollectionExtensions-Tests/CESequenceableCollectionExtensionTest.class.st
+++ b/src/CollectionExtensions-Tests/CESequenceableCollectionExtensionTest.class.st
@@ -5,19 +5,50 @@ Class {
 }
 
 { #category : #tests }
+CESequenceableCollectionExtensionTest >> testGroupsOfStep [
+	
+	"regular partition where all items are partitioned"
+	self
+		assert: (#(1 2 3 4 5) groupsOf: 2 step: 1)
+		equals: (OrderedCollection withAll: #(#(1 2) #(2 3) #(3 4) #(4 5))).
+		
+	self
+		assert: (#( 1 2 3 4 ) groupsOf: 2 step: 1)
+		equals: (OrderedCollection with: #( 1 2 ) with: #( 2 3 ) with: #(3 4)).
+
+	self
+		assert: (#( 1 2 3 4 5 6 7 ) groupsOf: 3 step: 2)
+		equals: (OrderedCollection withAll: #( #( 1 2 3 ) #( 3 4 5 ) #( 5 6 7 ) )) "7 is missing".
+	
+	"extra items that don't make up a full partition are included as last group"
+	self 
+		assert: (#(1 2 3 4 5 6) groupsOf: 3 step: 2)
+		equals: (OrderedCollection withAll: #( #(1 2 3) #(3 4 5) #(5 6))).
+						
+	"if step and n are equal, works like regular groupsOf:"
+	1 to: 10 do: [ :n | 
+ 		self 
+			assert: (#(1 2 3 4 5 6 7 8 9 10) groupsOf: n step: n)
+			equals: (#(1 2 3 4 5 6 7 8 9 10) groupsOf: n)
+	].
+
+	"step can also skip elements"
+	self
+		assert: (#(1 2 3 4 5 6 7) groupsOf: 2 step: 3)
+		equals: (OrderedCollection withAll: #(#(1 2) #(4 5) #(7))).
+	self 
+		assert: (#(1 2 3 4 5 6) groupsOf: 2 step: 4)
+		equals: (OrderedCollection  withAll: #(#(1 2) #(5 6))).
+		
+	
+
+
+]
+
+{ #category : #tests }
 CESequenceableCollectionExtensionTest >> testPairsSimilarityWith [
 	
 	self assert: ('1234' pairsSimilarityWith: '2234') equals: (2/3).
 	self assert: ('1234' pairsSimilarityWith: '123') equals: (4/5).
 	self assert: ('1234' pairsSimilarityWith: '5678') equals: 0
-]
-
-{ #category : #tests }
-CESequenceableCollectionExtensionTest >> testPartitionBy [
-	
-	"regular partition where all items are partitioned"
-	self assert: (#(1 2 3 4) partitionBy: 2) equals: #(#(1 2) #(3 4)). 
-	
-	"extra items that don't make up a full partition aren't included"
-	self assert: (#(1 2 3 4 5 6 7) partitionBy: 3) equals: #(#(1 2 3) #(4 5 6)). "7 is missing"
 ]

--- a/src/CollectionExtensions-Tests/CESequenceableCollectionExtensionTest.class.st
+++ b/src/CollectionExtensions-Tests/CESequenceableCollectionExtensionTest.class.st
@@ -11,3 +11,13 @@ CESequenceableCollectionExtensionTest >> testPairsSimilarityWith [
 	self assert: ('1234' pairsSimilarityWith: '123') equals: (4/5).
 	self assert: ('1234' pairsSimilarityWith: '5678') equals: 0
 ]
+
+{ #category : #tests }
+CESequenceableCollectionExtensionTest >> testPartitionBy [
+	
+	"regular partition where all items are partitioned"
+	self assert: (#(1 2 3 4) partitionBy: 2) equals: #(#(1 2) #(3 4)). 
+	
+	"extra items that don't make up a full partition aren't included"
+	self assert: (#(1 2 3 4 5 6 7) partitionBy: 3) equals: #(#(1 2 3) #(4 5 6)). "7 is missing"
+]

--- a/src/CollectionExtensions/SequenceableCollection.extension.st
+++ b/src/CollectionExtensions/SequenceableCollection.extension.st
@@ -27,6 +27,21 @@ SequenceableCollection >> pairsSimilarityWith: aSequenceableCollection [
 ]
 
 { #category : #'*CollectionExtensions' }
+SequenceableCollection >> partitionBy: count [ 
+	"Partition every count elements into an array. Answers with a collection (of the same type) of partitions.
+	#(1 2 3 4) partitionBy: 2 >>> #(#(1 2) #(3 4))"			
+	| i len |
+	i := 1.
+	len := self size.
+	^ self class streamContents: [ :out |
+		[ i + count <= (len + 1) ] whileTrue: [ 
+			out nextPut: (self copyFrom: i to: (i + count - 1)).
+			i := i + count.
+		]
+	]
+]
+
+{ #category : #'*CollectionExtensions' }
 SequenceableCollection >> piecesCutWhere: testBlock do: enumerationBlock [ 
 	"Evaluate testBlock for successive pairs of the receiver elements,
 	breaking the receiver into pieces between elements where

--- a/src/CollectionExtensions/SequenceableCollection.extension.st
+++ b/src/CollectionExtensions/SequenceableCollection.extension.st
@@ -28,7 +28,7 @@ SequenceableCollection >> pairsSimilarityWith: aSequenceableCollection [
 
 { #category : #'*CollectionExtensions' }
 SequenceableCollection >> partitionBy: count [ 
-	"Partition every count elements into an array. Answers with a collection (of the same type) of partitions.
+	"Partition every count elements into a sequence. Answers with a collection (of the same type) of partitions.
 	#(1 2 3 4) partitionBy: 2 >>> #(#(1 2) #(3 4))"			
 	| i len |
 	i := 1.

--- a/src/CollectionExtensions/SequenceableCollection.extension.st
+++ b/src/CollectionExtensions/SequenceableCollection.extension.st
@@ -1,6 +1,24 @@
 Extension { #name : #SequenceableCollection }
 
 { #category : #'*CollectionExtensions' }
+SequenceableCollection >> groupsOf: n step: step [ 
+	"Return groups of n elements, advancing starting position by step for each successive group.
+	 Answers with an ordered collection of groups.
+	#(1 2 3 4) groupsOf: 2 step: 1 >>> #(#(1 2) #(2 3) #(3 4))"			
+	| len i |
+	i := 1.
+	len := self size.
+	^ OrderedCollection streamContents: [ :out |
+		[ i+n-1 < len ] whileTrue: [
+ 			out nextPut: (self copyFrom: i to: i + n - 1).
+			i := i + step.
+		].
+		"include any left over elements in the last group"
+		i <= len ifTrue: [ out nextPut: (self copyFrom: i to: len) ]
+	]
+]
+
+{ #category : #'*CollectionExtensions' }
 SequenceableCollection >> pairsDistanceFrom: aSequenceableCollection [
 	
 	self deprecated: 'Please use pairsSimilarityWith:'.
@@ -24,21 +42,6 @@ SequenceableCollection >> pairsSimilarityWith: aSequenceableCollection [
 	aSequenceableCollection overlappingPairsDo: [:a :b | 
 		set2 add: a -> b].
 	^ 2 * (set1 intersection: set2) size / (set1 size + set2 size)
-]
-
-{ #category : #'*CollectionExtensions' }
-SequenceableCollection >> partitionBy: count [ 
-	"Partition every count elements into a sequence. Answers with a collection (of the same type) of partitions.
-	#(1 2 3 4) partitionBy: 2 >>> #(#(1 2) #(3 4))"			
-	| i len |
-	i := 1.
-	len := self size.
-	^ self class streamContents: [ :out |
-		[ i + count <= (len + 1) ] whileTrue: [ 
-			out nextPut: (self copyFrom: i to: (i + count - 1)).
-			i := i + count.
-		]
-	]
 ]
 
 { #category : #'*CollectionExtensions' }


### PR DESCRIPTION
Add a `partitionBy` method and test.

Don't know if something similar or more idiomatic is available, but I didn't find it. 

`#(1 2 3 4 5 6) partitionBy: 2 >>> #(#(1 2) #(3 4) #(5 6))`